### PR TITLE
Use imagen's new Node::Base#human_name when formatting

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     undercover (0.1.0)
-      imagen (~> 0.1.0)
+      imagen (~> 0.1.1)
       rainbow (~> 3.0.0)
       rugged (~> 0.27.0)
 
@@ -13,7 +13,7 @@ GEM
     coderay (1.1.2)
     diff-lcs (1.3)
     docile (1.3.0)
-    imagen (0.1.0)
+    imagen (0.1.1)
       parser
     json (2.1.0)
     method_source (0.9.0)

--- a/lib/undercover/formatter.rb
+++ b/lib/undercover/formatter.rb
@@ -15,7 +15,7 @@ module Undercover
 
     def formatted_warnings
       @results.map.with_index(1) do |res, idx|
-        "🚨 #{idx}) node `#{res.node.name}` type: #{res.node.class},\n" +
+        "🚨 #{idx}) node `#{res.node.name}` type: #{res.node.human_name},\n" +
           (' ' * pad_size) + "loc: #{res.file_path_with_lines}," \
           " coverage: #{res.coverage_f * 100}%\n" +
           res.pretty_print

--- a/spec/formatter_spec.rb
+++ b/spec/formatter_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'undercover'
+require 'pry'
+
+describe Undercover::Formatter do
+  context 'without warnings' do
+    let(:results) { {} }
+
+    it 'returns a message' do
+      formatted = described_class.new(results).to_s
+      puts formatted
+      expect(formatted).to include('No coverage is missing in latest changes')
+    end
+  end
+
+  context 'with warnings' do
+    let(:ast) { Imagen.from_local('spec/fixtures/class.rb') }
+    let(:lcov) do
+      Undercover::LcovParser.parse('spec/fixtures/fixtures.lcov')
+    end
+    let(:coverage) { lcov.source_files['spec/fixtures/class.rb'] }
+    let(:node) { ast.find_all(with_name('BaconClass')).first }
+    let(:result) { Undercover::Result.new(node, coverage, 'class.rb') }
+
+    let(:results) { [result] }
+
+    it 'returns a useful message' do
+      formatted = described_class.new(results).to_s
+      expect(formatted).to include('some methods have no test coverage')
+      expect(formatted).to include('node `BaconClass`')
+      expect(formatted).to include('type: class')
+      expect(formatted).to include('loc: class.rb:3:18')
+      expect(formatted).to include('coverage: 83.33%')
+    end
+  end
+end

--- a/undercover.gemspec
+++ b/undercover.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'imagen', '~> 0.1.0'
+  spec.add_dependency 'imagen', '~> 0.1.1'
   spec.add_dependency 'rainbow', '~> 3.0.0'
   spec.add_dependency 'rugged', '~> 0.27.0'
 


### PR DESCRIPTION
### Blocked by:
- [x] Releasing updated version of imagen
- [x] Updating imagen dep

### Things to consider:
- [x] Adding a test that would faild shall a method that does not exists be used in `Undercover::Formatter`