### PR TITLE
Fix long form of Ruby syntax option

### DIFF
--- a/lib/undercover/options.rb
+++ b/lib/undercover/options.rb
@@ -89,7 +89,7 @@ module Undercover
     def ruby_syntax_option(parser)
       versions = Imagen::AVAILABLE_RUBY_VERSIONS.sort.join(', ')
       desc = "Ruby syntax version, one of: #{versions}"
-      parser.on('-r', '--ruby-synax ver', desc) do |version|
+      parser.on('-r', '--ruby-syntax ver', desc) do |version|
         self.syntax_version = version.strip
       end
     end

--- a/lib/undercover/version.rb
+++ b/lib/undercover/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Undercover
-  VERSION = '0.2.2'
+  VERSION = '0.2.3'
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -114,6 +114,9 @@ describe Undercover::CLI do
     subject.run('-r ruby19')
     expect(Imagen.parser_version).to eq('ruby19')
 
+    subject.run(%w[--ruby-syntax ruby20])
+    expect(Imagen.parser_version).to eq('ruby20')
+
     Imagen.parser_version = v_default
   end
 


### PR DESCRIPTION
There was a typo that caused the long form not to work properly. Added an assertion to the test too.