### PR TITLE
Allow any character in file names when parsing lcov file

### DIFF
--- a/lib/undercover/lcov_parser.rb
+++ b/lib/undercover/lcov_parser.rb
@@ -27,7 +27,7 @@ module Undercover
     # rubocop:disable Metrics/MethodLength, Style/SpecialGlobalVars
     def parse_line(line)
       case line
-      when /^SF:([\.\/\w]+)/
+      when /^SF:(.+)/
         @current_filename = $~[1].gsub(/^\.\//, '')
         source_files[@current_filename] = []
       when /^DA:(\d+),(\d+)/


### PR DESCRIPTION
Allows for non-word characters in a file name in the LCOV file.

Fixes issue #57 