### PR TITLE
Add Ruby 3.1 to CI matrix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -5,11 +5,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['3.0.x', '2.7.x', '2.6.x', '2.5.x']
+        ruby: ['3.1', '3.0', '2.7', '2.6', '2.5']
     steps:
       - uses: actions/checkout@v1
       - name: Set up Ruby ${{ matrix.ruby }}
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
       - name: Build and test with Rake


### PR DESCRIPTION
To get CI running I needed to switch to a supported setup-ruby action (`ruby/setup-ruby`) and remove the trailing '.x' from each of the version strings.