### PR TITLE
Minor: Do not raise on malformed lcov

### DIFF
--- a/lib/undercover/lcov_parser.rb
+++ b/lib/undercover/lcov_parser.rb
@@ -69,8 +69,6 @@ module Undercover
         source_files[@current_filename] << [line_no.to_i, block_no.to_i, branch_no.to_i, covered.to_i]
       when /^end_of_record$/, /^$/
         @current_filename = nil
-      else
-        raise LcovParseError, "could not recognise '#{line}' as valid LCOV"
       end
     end
     # rubocop:enable Metrics/MethodLength, Style/SpecialGlobalVars, Metrics/AbcSize

--- a/spec/lcov_parser_spec.rb
+++ b/spec/lcov_parser_spec.rb
@@ -43,10 +43,10 @@ describe Undercover::LcovParser do
     expect { parser.parse }.not_to raise_error
   end
 
-  it 'raises an error with a malformed LCOV' do
+  it 'doesnt raise an error with a malformed LCOV' do
     parser = described_class.new(StringIO.new('baconium!'))
 
-    expect { parser.parse }.to raise_error(Undercover::LcovParseError)
+    expect { parser.parse }.not_to raise_error(Undercover::LcovParseError)
   end
 
   it 'includes total coverage data' do


### PR DESCRIPTION
I'm working on adding js coverage to our codebase, the lcov provided by nyc is valid though undercover raises as if it was invalid.

lcov format is more than just SF/DA/BRF/BRH/BRDA/end_of_record, in nyc lcov for example there is: TN/FN/FNF/FNH/FNDA/LF/LH

I think it would be better to just skip unknown lines instead of raising, I wanted to add some log but there is no logger facility in the project atm.