### PR TITLE
Fix: Update of one-line block is ignored

### DIFF
--- a/lib/undercover/result.rb
+++ b/lib/undercover/result.rb
@@ -13,7 +13,7 @@ module Undercover
     def initialize(node, file_cov, file_path)
       @node = node
       @coverage = file_cov.select do |ln, _|
-        ln > first_line && ln < last_line
+        first_line == last_line ? ln == first_line : ln > first_line && ln < last_line
       end
       @file_path = file_path
       @flagged = false

--- a/spec/fixtures/one_line_block.lcov
+++ b/spec/fixtures/one_line_block.lcov
@@ -1,0 +1,7 @@
+SF:./one_line_block.rb
+DA:2,1
+DA:3,1
+DA:4,1
+DA:6,1
+DA:7,0
+end_of_record

--- a/spec/fixtures/one_line_block.rb
+++ b/spec/fixtures/one_line_block.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+class BaconClass
+  # types of bacon
+  BACON_TYPES = %w[peameal back bacon].freeze
+
+  def favorite
+    BACON_TYPES.select{ |type| type == 'back bacon'} 
+  end
+end

--- a/spec/result_spec.rb
+++ b/spec/result_spec.rb
@@ -60,4 +60,19 @@ describe Undercover::Result do
       expect(result.uncovered?(27)).to be_falsy
     end
   end
+
+  context 'for oneline block uncovered' do
+    let(:ast) { Imagen.from_local('spec/fixtures/one_line_block.rb') }
+    let(:lcov) do
+      Undercover::LcovParser.parse('spec/fixtures/one_line_block.lcov')
+    end
+    let(:coverage) { lcov.source_files['one_line_block.rb'] }
+
+    it 'uncovered gives true' do
+      node = ast.children[0].find_all(->(_) { true }).last
+      result = described_class.new(node, coverage, 'one_line_block.rb')
+
+      expect(result.uncovered?(7)).to be_truthy
+    end
+  end
 end


### PR DESCRIPTION
**What I fixed?**

issue: https://github.com/grodowski/undercover/issues/204

When I update a one-line block, the `first_line` and `last_line` of the `Result` object are the same, and the `@coverage` becomes an empty array, resulting in `uncovered?` returning nil (which means covered).

**How I fixed?**

Add an assessment for a one-line block. I also added a test for this scenario.
