### PR TITLE
Do not set `options.lcov` using `guess_lcov_path` when `simplecov_resultset` has already been set

### DIFF
--- a/lib/undercover/options.rb
+++ b/lib/undercover/options.rb
@@ -86,7 +86,7 @@ module Undercover
       end.parse(args)
 
       guess_resultset_path unless simplecov_resultset
-      guess_lcov_path unless lcov
+      guess_lcov_path unless simplecov_resultset || lcov
       self
     end
     # rubocop:enable Metrics/MethodLength, Metrics/AbcSize

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -27,6 +27,13 @@ describe Undercover::Options do
       expect(options).to receive(:guess_resultset_path)
       options.parse([])
     end
+
+    it 'does not call guess_lcov_path when simplecov_resultset is set' do
+      options.simplecov_resultset = 'test.json'
+      expect(options).not_to receive(:guess_lcov_path)
+      options.parse([])
+      expect(options.lcov).to be_nil
+    end
   end
 
   describe '#guess_resultset_path' do


### PR DESCRIPTION
Prevents [lib/undercover.rb:42](https://github.com/grodowski/undercover/blob/master/lib/undercover.rb#L42) from erroring out when using simplecov instead of lcov.