### PR TITLE
Fix SimpleCov filters

### DIFF
--- a/lib/undercover/filter_set.rb
+++ b/lib/undercover/filter_set.rb
@@ -24,6 +24,7 @@ module Undercover
 
     def ignored_by_simplecov?(filepath)
       simplecov_filters.any? do |filter|
+        filter = filter.transform_keys(&:to_sym)
         if filter[:string]
           filepath.include?(filter[:string])
         elsif filter[:regex]

--- a/spec/filter_set_spec.rb
+++ b/spec/filter_set_spec.rb
@@ -58,9 +58,9 @@ describe Undercover::FilterSet do
     context 'with string and regex filters' do
       let(:simplecov_filters) do
         [
-          {string: 'spec/'},
-          {regex: '\/test\/'},
-          {file: 'custom_ignored.rb'},
+          {'string' => 'spec/'},
+          {'regex' => '\/test\/'},
+          {'file' => 'custom_ignored.rb'},
         ]
       end
 


### PR DESCRIPTION
SimpleCov filters seems to be not working due `FilterSet` expects symbol keys although `JSON.parse` produces string keys.

Please look at this sample rails application. I've made 2 pull-requests with the current version of **undercover** and forked version. In both of them `add_filter 'pek'` was added for SimpleCov so that coverage check should be skipped for the new PekController.
- [CI for origin version](https://github.com/loadkpi/test_undercover/pull/2 ) failed with because of "[some methods have no test coverage](https://github.com/loadkpi/test_undercover/actions/runs/18020484877/job/51276392843?pr=2#step:5:5)"
- [CI for forked version](https://github.com/loadkpi/test_undercover/pull/3) is [green](https://github.com/loadkpi/test_undercover/actions/runs/18020718877/job/51277178225?pr=3#step:5:5)
